### PR TITLE
Changes skin for accessibility...

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,7 +30,7 @@ permalink: pretty
 
 # Theme settings
 remote_theme: mmistakes/minimal-mistakes@4.19.0
-minimal_mistakes_skin: 'contrast'
+minimal_mistakes_skin: 'air'
 title_separator: '|'
 teaser: /assets/images/electronics-repair.jpg # fallback teaser, overridden in page yaml
 logo: /assets/images/rhino.png


### PR DESCRIPTION
The "Air" skin for Minimal Mistakes is the most accessible option available
for colorblind users, particularly those with protanopia/protanomaly, the
most common form of colorblindness