### PR TITLE
Issue #178 - Add key-value pair to pull GitHub Metadata

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -64,3 +64,6 @@ timezone: America/Detroit
 
 # simulate github pages
 safe: true
+
+# add key-value pair to pull GitHub Metadata
+github: [metadata]


### PR DESCRIPTION
Pair pulls GitHub Metadata automatically. This change removes "GitHub Metadata: No GitHub API authentication could be found. Some fields may be missing or have incorrect data." warning when running bundle exec jekyll [whatever] commands.