### PR TITLE
accessibility: make matrix link clickable

### DIFF
--- a/contact.md
+++ b/contact.md
@@ -25,9 +25,9 @@ info@allhandsactive.org
 255 E. Liberty St. Suite 225<br/>
 Ann Arbor, MI 48104
 
-## Public Chat
+## Public Chat (Matrix)
 
-https://chat.allhandsactive.org/
+[https://chat.allhandsactive.org/]()
 
 ## Internet Relay Chat
 


### PR DESCRIPTION
change matrix to a clickable link in order to make 
it easier to access, rather than requiring someone 
a copy paste or other workaround

additionally make it clear that its just a matrix
instance in the event that someone is trying to
find the Matrix specifically


![image](https://github.com/user-attachments/assets/ed93b9f5-d455-49e1-a966-0c0bd5113b42)
