### PR TITLE
refactor: move mailchimp sign up form to an includes file

### DIFF
--- a/_includes/mailchimp-form.html
+++ b/_includes/mailchimp-form.html
@@ -1,0 +1,15 @@
+<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
+<style type="text/css">
+  #mc_embed_signup{background:#eee; clear:left; font:14px Helvetica,Arial,sans-serif; width:100%;}
+  form{background:#eee;}
+</style>
+<div id="mc_embed_signup">
+  <form action="https://allhandsactive.us4.list-manage.com/subscribe/post?u=0497c04d5751340fb683e3d14&amp;id=5612521156" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+    <div id="mc_embed_signup_scroll">
+      <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" style="height: 3em;padding: .5em 1em;font-size: 1.2em;font-weight: bold;" required>
+      <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+      <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_0497c04d5751340fb683e3d14_5612521156" tabindex="-1" value=""></div>
+      <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button" style="background:#0092CA; color:#fff; padding: 0.5em 1em; height: 3em; font-size: 1.2em; font-weight:bold;"></div>
+    </div>
+  </form>
+</div>

--- a/cancel.md
+++ b/cancel.md
@@ -21,22 +21,7 @@ All Hands Active is committed to spreading knowledge. We won't keep anyone from 
 ### Stay informed about all things All Hands Active! 
 Sign up for our email list or follow us on social media (at the bottom of the page).
 
-<!-- Begin Mailchimp Signup Form -->
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<style type="text/css">
-  #mc_embed_signup{background:#eee; clear:left; font:14px Helvetica,Arial,sans-serif; width:100%;}
-  form{background:#eee;}
-</style>
-<div id="mc_embed_signup">
-<form action="https://allhandsactive.us4.list-manage.com/subscribe/post?u=0497c04d5751340fb683e3d14&amp;id=5612521156" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-      <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" style="height: 3em;padding: .5em 1em;font-size: 1.2em;font-weight: bold;" required>
-      <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-      <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_0497c04d5751340fb683e3d14_5612521156" tabindex="-1" value=""></div>
-      <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button" style="background:#0092CA; color:#fff; padding: 0.5em 1em; height: 3em; font-size: 1.2em; font-weight:bold;"></div>
-    </div>
-  </form>
-</div>
+{% include mailchimp-form.html %}
 
 ### Find another class
 Check our [calendar](https://www.meetup.com/AllHandsActive/events/) right now. Or contact us at <board@allhandsactive.org> and let us know what you want to learn.

--- a/class.md
+++ b/class.md
@@ -9,22 +9,7 @@ We're sure you're excited about that class. In the meantime, you might want to f
 ## Stay informed about all things All Hands Active! 
 Sign up for our email list or follow us on social media (at the bottom of the page).
 
-<!-- Begin Mailchimp Signup Form -->
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<style type="text/css">
-  #mc_embed_signup{background:#eee; clear:left; font:14px Helvetica,Arial,sans-serif; width:100%;}
-  form{background:#eee;}
-</style>
-<div id="mc_embed_signup">
-<form action="https://allhandsactive.us4.list-manage.com/subscribe/post?u=0497c04d5751340fb683e3d14&amp;id=5612521156" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-      <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" style="height: 3em;padding: .5em 1em;font-size: 1.2em;font-weight: bold;" required>
-      <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-      <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_0497c04d5751340fb683e3d14_5612521156" tabindex="-1" value=""></div>
-      <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button" style="background:#0092CA; color:#fff; padding: 0.5em 1em; height: 3em; font-size: 1.2em; font-weight:bold;"></div>
-    </div>
-  </form>
-</div>
+{% include mailchimp-form.html %}
 
 ## Find another class
 Check our [calendar](https://www.meetup.com/AllHandsActive/events/) right now. Or contact us at <board@allhandsactive.org> and let us know what you want to learn.

--- a/index.md
+++ b/index.md
@@ -45,19 +45,4 @@ feature_row2:
 Join our announcements email list!
 {: .text-center}
 
-<!-- Begin Mailchimp Signup Form -->
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<style type="text/css">
-  #mc_embed_signup{background:#eee; clear:left; font:14px Helvetica,Arial,sans-serif; width:100%;}
-  form{background:#eee;}
-</style>
-<div id="mc_embed_signup">
-  <form action="https://allhandsactive.us4.list-manage.com/subscribe/post?u=0497c04d5751340fb683e3d14&amp;id=5612521156" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-      <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" style="height: 3em;padding: .5em 1em;font-size: 1.2em;font-weight: bold;" required>
-      <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-      <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_0497c04d5751340fb683e3d14_5612521156" tabindex="-1" value=""></div>
-      <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button" style="background:#0092CA; color:#fff; padding: 0.5em 1em; height: 3em; font-size: 1.2em; font-weight:bold;"></div>
-    </div>
-  </form>
-</div>
+{% include mailchimp-form.html %}

--- a/membership.md
+++ b/membership.md
@@ -96,19 +96,4 @@ on the mailing list to fixing something that's broken.
 Stay informed about all things All Hands Active!
 {: .text-center}
 
-<!-- Begin Mailchimp Signup Form -->
-<link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css">
-<style type="text/css">
-  #mc_embed_signup{background:#eee; clear:left; font:14px Helvetica,Arial,sans-serif; width:100%;}
-  form{background:#eee;}
-</style>
-<div id="mc_embed_signup">
-  <form action="https://allhandsactive.us4.list-manage.com/subscribe/post?u=0497c04d5751340fb683e3d14&amp;id=5612521156" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-      <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" style="height: 3em;padding: .5em 1em;font-size: 1.2em;font-weight: bold;" required>
-      <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-      <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_0497c04d5751340fb683e3d14_5612521156" tabindex="-1" value=""></div>
-      <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button" style="background:#0092CA; color:#fff; padding: 0.5em 1em; height: 3em; font-size: 1.2em; font-weight:bold;"></div>
-    </div>
-  </form>
-</div>
+{% include mailchimp-form.html %}


### PR DESCRIPTION
Move the mailchimp form to a single file in order to cut down on repeated code, and make it easier to update in the future. 

closes #67 
supersedes and closes #134