### PR TITLE
feat: remove inline styles where possible from markdown

### DIFF
--- a/contact.md
+++ b/contact.md
@@ -18,11 +18,11 @@ excerpt: "Reach us by email, or visit us in person."
 
 ## Email
 
-info@allhandsactive.org
+[info@allhandsactive.org](mailto:info@allhandsactive.org)
 
 ## Mailing address
 
-255 E. Liberty St. Suite 225<br/>
+255 E. Liberty St. Suite 225 \
 Ann Arbor, MI 48104
 
 ## Public Chat (Matrix)
@@ -31,18 +31,4 @@ Ann Arbor, MI 48104
 
 ## Internet Relay Chat
 
-\#allhandsactive<br />
-on the <a href="https://tilde.chat/">tilde.chat</a> IRC network
-
-
-<!--## Contact Form
-
-Use this form to send us an email
-
-<form action="#" style="width: 50%">
-  <input type="text" name="first_name" placeholder="Jane" aria-label="first name" style="width: 46.5%; float: left; margin-bottom: 1em" />
-  <input type="text" name="last_name" placeholder="Smith" aria-label="last name" style="width: 46.5%; float: right; margin-bottom: 1em" />
-  <input type="email" name="email" aria-label="email" style="margin-bottom: 1em" placeholder="jane.smith@gmail.com" />
-  <textarea cols="46" rows="5" name="comments" aria-label="comments" style="margin-bottom: 1em" placeholder="Send us a message"></textarea>
-  <input class="btn btn--primary" type="submit" value="Submit" />
-</form>-->
+\#allhandsactive on the [tilde.chat](https://tilde.chat/) IRC network.

--- a/membership.md
+++ b/membership.md
@@ -69,7 +69,7 @@ on the mailing list to fixing something that's broken.
 1. Complete and submit the [liability form](https://rhino.li/liability-waiver-form) in person.
 2. Read and understand our [Anti-Harassment Policy](https://rhino.li/anti-harassment-policy).
 3. Fill out our [new member form](https://rhino.li/membership-application) online.
-4. Make arrangements for payment. Paying via PayPal (see below) is a great option, but you may also pay via cash or check. Contact board@allhandsactive.org to arrange anything other than paypal.
+4. Make arrangements for payment. Paying via PayPal (see below) is a great option, but you may also pay via cash or check. Contact [board@allhandsactive.org](mailto:board@allhandsactive.org) to arrange anything other than paypal.
 5. (optional) For key-card any-time access to the space, complete your first month's volunteer hours and then contact [board@allhandsactive.org](mailto:board@allhandsactive.org) or use the operations channel on [Matrix](https://chat.allhandsactive.org). Matrix is also a great place to find volunteer opportunities.
 
 ## Pay For a Membership via Paypal

--- a/reservations.md
+++ b/reservations.md
@@ -18,14 +18,5 @@ excerpt: "Reservations are no longer required before visiting All Hands Active."
 ---
 
 ## How to Use The Space
-<p>All Hands Active is currently open to members at any time. Non-members may come to open hours listed in our <a href="https://www.meetup.com/AllHandsActive/events/">events calendar</a> or contact <a
-href="mailto:board@allhandsactive.org">board@allhandsactive.org</a> to schedule
-a visit.</p> 
-<!---
-<p>The calendar below shows the availability of the
-space. Please check your time and then use the form to make a reservation.</p>
 
-<iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;ctz=America%2FNew_York&amp;src=YWxsaGFuZHNhY3RpdmUub3JnX3B2c2t1ZGthY2poNmtrNTc5aDVmbXRtcG9zQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20&amp;src=YWxsaGFuZHNhY3RpdmUub3JnX203c3FlMXYzMGFtZWVncXFoam42bmFobjlrQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20&amp;src=YWxsaGFuZHNhY3RpdmUub3JnX3FhNmtmdW41amVsMmY3cHQ5b3Nlc3NibWdnQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20&amp;color=%23F09300&amp;color=%237986CB&amp;color=%239E69AF&amp;title=All%20Hands%20Active%20Room%20Reservations" style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"></iframe>
-<br>
-<iframe src="https://docs.google.com/forms/d/e/1FAIpQLSemfD9IU6othxtFbF-HbHx2ohWgv0ra2Pb2XuRwXG_A8wBfaA/viewform?embedded=true" width="640" height="1977" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
--->
+All Hands Active is open to members 24/7. Non-members may come to open hours listed in our [events](https://www.meetup.com/AllHandsActive/events/) or contact [board@allhandsactive.org](mailto:board@allhandsactive.org) to schedule a visit.


### PR DESCRIPTION
closes #53 

Couldn't remove the inline styles from the titles in the memberships page, as markdown is not supported in those fields. Other than that, removed all inline styles that weren't a form.