### PR TITLE
fix: remove the social media variables

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,13 +12,6 @@ baseurl: ''
 url: 'https://allhandsactive.org'
 repository: 'allhandsactive/site'
 
-# Social media variables
-twitter_username: AllHandsActive
-facebook_username: AHA-All-Hands-Active-300100514925
-meetup_username: allhandsactive
-github_username:  allhandsactive
-mastodon_username: aha@a2mi.social
-
 # Build settings
 kramdown:
   input: GFM


### PR DESCRIPTION
These have been a source of confusion by jekyll for many years. They are
only used in the default theme and aren't actually used by jekyll itself
for any purpose.

The theme minimal-mistakes does not use these variables for social media
or footer links, but instead those links are provided seperately. So
these variables are unused and don't actually fuel anything.

See https://github.com/jekyll/jekyll/issues/4556
