### PR TITLE
fix: colorize social media icons with brand colors

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -5,3 +5,4 @@
 <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
 <meta name="msapplication-TileColor" content="#da532c">
 <meta name="theme-color" content="#ffffff">
+<link rel="stylesheet" href="/assets/css/icons.css">

--- a/assets/css/icons.css
+++ b/assets/css/icons.css
@@ -1,0 +1,11 @@
+ul.social-icons i.fa-meetup {
+    color: #ed1c40;
+}
+
+ul.social-icons i.fa-mastodon {
+    color: #563ACC;
+}
+
+ul.social-icons i.fa-instagram {
+    color: #8b02a0;
+}


### PR DESCRIPTION
This also fixes the default mastodon blue from blending into our footer.

Depends on #225 