### PR TITLE
fix: add donate and email links to supporters page

### DIFF
--- a/supporters.md
+++ b/supporters.md
@@ -6,6 +6,11 @@ header:
   overlay_color: "#000"
   overlay_filter: "0.6"
   overlay_image: /assets/images/donationbox.jpg
+  actions:
+    - label: "Email"
+      url: "mailto:info@allhandsactive.org"
+    - label: "Donate"
+      url: "/donate"
 excerpt: "These companies and individuals help keep our lights on."
 ---
 


### PR DESCRIPTION
the page references the donate and email buttons on this page that don't exist
